### PR TITLE
Add pagination

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -80,11 +80,13 @@ const (
 )
 
 // Add RBAC for the authorized diagnostics endpoint.
-// +kubebuilder:rbac:groups=authentication.k8s.io,resources=tokenreviews,verbs=create
-// +kubebuilder:rbac:groups=authorization.k8s.io,resources=subjectaccessreviews,verbs=create
+//+kubebuilder:rbac:groups=authentication.k8s.io,resources=tokenreviews,verbs=create
+//+kubebuilder:rbac:groups=authorization.k8s.io,resources=subjectaccessreviews,verbs=create
 
 // Add RBAC to detect if ClusterAPI is installed
 //+kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list;watch
+
+//+kubebuilder:rbac:groups=lib.projectsveltos.io,resources=debuggingconfigurations,verbs=get;list;watch
 
 func main() {
 	scheme, err := controller.InitScheme()

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -43,6 +43,14 @@ rules:
 - apiGroups:
   - lib.projectsveltos.io
   resources:
+  - debuggingconfigurations
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - lib.projectsveltos.io
+  resources:
   - sveltosclusters
   verbs:
   - get

--- a/internal/server/export_test.go
+++ b/internal/server/export_test.go
@@ -1,0 +1,21 @@
+/*
+Copyright 2024. projectsveltos.io. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server
+
+var (
+	GetLimitedClusters = getLimitedClusters
+)

--- a/internal/server/managed_cluster_test.go
+++ b/internal/server/managed_cluster_test.go
@@ -1,0 +1,96 @@
+/*
+Copyright 2024. projectsveltos.io. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server_test
+
+import (
+	"reflect"
+	"sort"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/projectsveltos/ui-backend/internal/server"
+)
+
+var _ = Describe("ManageClusters", func() {
+	It("Clusters are sorted by Namespace/Name", func() {
+		managedClusters := make(server.ManagedClusters, 0)
+		for i := 0; i < 10; i++ {
+			cluster := server.ManagedCluster{
+				Namespace: randomString(),
+				Name:      randomString(),
+			}
+
+			managedClusters = append(managedClusters, cluster)
+		}
+
+		sort.Sort(managedClusters)
+
+		var previousNamespace string
+		for i := range managedClusters {
+			if i == 0 {
+				previousNamespace = managedClusters[i].Namespace
+			} else {
+				Expect(previousNamespace < managedClusters[i].Namespace)
+				previousNamespace = managedClusters[i].Namespace
+			}
+		}
+	})
+
+	It("getLimitedClusters returns the right set of clusters", func() {
+		managedClusters := make(server.ManagedClusters, 0)
+		for i := 0; i < 10; i++ {
+			cluster := server.ManagedCluster{
+				Namespace: randomString(),
+				Name:      randomString(),
+			}
+
+			managedClusters = append(managedClusters, cluster)
+		}
+
+		sort.Sort(managedClusters)
+
+		limit := 1
+		skip := 3
+		result, err := server.GetLimitedClusters(managedClusters, limit, skip)
+		Expect(err).To(BeNil())
+		for i := 0; i < limit; i++ {
+			Expect(reflect.DeepEqual(result[i], managedClusters[skip+i]))
+		}
+
+		limit = 3
+		skip = 5
+		result, err = server.GetLimitedClusters(managedClusters, limit, skip)
+		Expect(err).To(BeNil())
+		for i := 0; i < limit; i++ {
+			Expect(reflect.DeepEqual(result[i], managedClusters[skip+i]))
+		}
+
+		limit = 3
+		skip = 9
+		result, err = server.GetLimitedClusters(managedClusters, limit, skip)
+		Expect(err).To(BeNil())
+		// limit is 3 but skip starts from 9. Original number of clusters is 10. So expect only 1 cluster
+		Expect(len(result)).To(Equal(1))
+		Expect(reflect.DeepEqual(result[0], managedClusters[skip]))
+
+		limit = 3
+		skip = 11
+		_, err = server.GetLimitedClusters(managedClusters, limit, skip)
+		Expect(err).ToNot(BeNil())
+	})
+})

--- a/internal/server/managed_clusters.go
+++ b/internal/server/managed_clusters.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2024. projectsveltos.io. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server
+
+import (
+	"errors"
+)
+
+type ManagedCluster struct {
+	Namespace   string `json:"namespace"`
+	Name        string `json:"name"`
+	ClusterInfo `json:"clusterInfo"`
+}
+
+type ManagedClusters []ManagedCluster
+
+func (s ManagedClusters) Len() int      { return len(s) }
+func (s ManagedClusters) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
+func (s ManagedClusters) Less(i, j int) bool {
+	if s[i].Namespace == s[j].Namespace {
+		return s[i].Name < s[j].Name
+	}
+	return s[i].Namespace < s[j].Namespace
+}
+
+func getLimitedClusters(clusters ManagedClusters, limit, skip int) (ManagedClusters, error) {
+	if skip < 0 {
+		return nil, errors.New("skip cannot be negative")
+	}
+	if limit < 0 {
+		return nil, errors.New("limit cannot be negative")
+	}
+	if skip >= len(clusters) {
+		return nil, errors.New("skip cannot be greater than or equal to the length of the slice")
+	}
+
+	// Adjust limit based on slice length and skip
+	adjustedLimit := limit
+	if skip+limit > len(clusters) {
+		adjustedLimit = len(clusters) - skip
+	}
+
+	// Use slicing to extract the desired sub-slice
+	return clusters[skip : skip+adjustedLimit], nil
+}

--- a/internal/server/manager_test.go
+++ b/internal/server/manager_test.go
@@ -23,10 +23,10 @@ import (
 	"reflect"
 	"time"
 
-	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/manifest/manifest.yaml
+++ b/manifest/manifest.yaml
@@ -60,6 +60,14 @@ rules:
 - apiGroups:
   - lib.projectsveltos.io
   resources:
+  - debuggingconfigurations
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - lib.projectsveltos.io
+  resources:
   - sveltosclusters
   verbs:
   - get


### PR DESCRIPTION
```
/capiclusters?limit=6&skip=6
```

will return up to 6 ClusterAPI powered clusters, starting from cluster at index 6

Same applies to SveltosClusters