### PR TITLE
Add filters to GET clusters API

### DIFF
--- a/internal/server/export_test.go
+++ b/internal/server/export_test.go
@@ -17,5 +17,21 @@ limitations under the License.
 package server
 
 var (
-	GetLimitedClusters = getLimitedClusters
+	GetClustersInRange = getClustersInRange
 )
+
+var (
+	GetClusterFiltersFromQuery = getClusterFiltersFromQuery
+)
+
+func GetNamespaceFilter(f clusterFilters) string {
+	return f.Namespace
+}
+
+func GetNameFilter(f clusterFilters) string {
+	return f.name
+}
+
+func GetLabelFilter(f clusterFilters) string {
+	return f.labelSelector.String()
+}


### PR DESCRIPTION
When requesting both ClusterAPI powered clusters (/capiclusters) and SveltosClusters (/sveltosclusters) following filters are added:

1. namespace=<namespace>: this filter allows selecting clusters in namespaces containing such string
2. name=<name>: this filter allows selecting clusters with a name containing such string
3. labels=<key1:value1,key2:value2> (labels must be encoded to form a correct URI)

This PR also returns the total number of clusters matching all filters.

For instance:
```
http://localhost:9000/capiclusters?limit=1&skip=0&namespace=default&labels=env:fv,cluster.x-k8s.io%2Fcluster-name:clusterapi-workload
```

will return:
```
{"totalClusters":1,"managedClusters":[{"namespace":"default","name":"clusterapi-workload","clusterInfo":{"labels":{"cluster.x-k8s.io/cluster-name":"clusterapi-workload","env":"fv","topology.cluster.x-k8s.io/owned":""},"version":"v1.27.0","ready":true,"failureMessage":null}}]}
```

Fixes #7 #6 
