### PR TITLE
When there are no result, return empty array

### DIFF
--- a/internal/server/addons.go
+++ b/internal/server/addons.go
@@ -274,6 +274,10 @@ func addDeployedResourcesForFeature(profileName string,
 }
 
 func getHelmReleaseInRange(helmReleases []HelmRelease, limit, skip int) ([]HelmRelease, error) {
+	if len(helmReleases) == 0 {
+		return helmReleases, nil
+	}
+
 	if skip < 0 {
 		return nil, errors.New("skip cannot be negative")
 	}
@@ -295,6 +299,10 @@ func getHelmReleaseInRange(helmReleases []HelmRelease, limit, skip int) ([]HelmR
 }
 
 func getResourcesInRange(resources []Resource, limit, skip int) ([]Resource, error) {
+	if len(resources) == 0 {
+		return resources, nil
+	}
+
 	if skip < 0 {
 		return nil, errors.New("skip cannot be negative")
 	}

--- a/internal/server/managed_clusters.go
+++ b/internal/server/managed_clusters.go
@@ -47,6 +47,10 @@ func (s ManagedClusters) Less(i, j int) bool {
 }
 
 func getClustersInRange(clusters ManagedClusters, limit, skip int) (ManagedClusters, error) {
+	if len(clusters) == 0 {
+		return clusters, nil
+	}
+
 	if skip < 0 {
 		return nil, errors.New("skip cannot be negative")
 	}


### PR DESCRIPTION
A check on skip value (when no results are available) was causing thr query to return a 400 error.

This PR fixes that.