### PR TITLE
Various fixes

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -49,6 +49,22 @@ rules:
   - list
   - watch
 - apiGroups:
+  - config.projectsveltos.io
+  resources:
+  - clustersummaries
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - config.projectsveltos.io
+  resources:
+  - clustersummaries/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - lib.projectsveltos.io
   resources:
   - debuggingconfigurations

--- a/internal/controller/clustersummary_controller.go
+++ b/internal/controller/clustersummary_controller.go
@@ -24,6 +24,9 @@ type ClusterSummaryReconciler struct {
 	ConcurrentReconciles int
 }
 
+//+kubebuilder:rbac:groups=config.projectsveltos.io,resources=clustersummaries,verbs=get;list;watch
+//+kubebuilder:rbac:groups=config.projectsveltos.io,resources=clustersummaries/status,verbs=get;list;watch
+
 func (r *ClusterSummaryReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := ctrl.LoggerFrom(ctx)
 	logger.V(logs.LogInfo).Info("Reconciling")

--- a/internal/server/addons_test.go
+++ b/internal/server/addons_test.go
@@ -18,9 +18,13 @@ package server_test
 
 import (
 	"reflect"
+	"sort"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/projectsveltos/ui-backend/internal/server"
 )
@@ -114,5 +118,107 @@ var _ = Describe("Deployed Addons and Applications", func() {
 		skip = 11
 		_, err = server.GetResourcesInRange(resources, limit, skip)
 		Expect(err).ToNot(BeNil())
+	})
+
+	It("sortResources sorts resources by applied time first and GVK then", func() {
+		time1 := metav1.Time{Time: time.Now()}
+		resources := make([]server.Resource, 0)
+		for i := 0; i < 10; i++ {
+			resource := server.Resource{
+				Namespace:       randomString(),
+				Name:            randomString(),
+				Group:           randomString(),
+				Version:         randomString(),
+				Kind:            randomString(),
+				ProfileNames:    []string{randomString()},
+				LastAppliedTime: &time1,
+			}
+
+			resources = append(resources, resource)
+		}
+
+		time2 := metav1.Time{Time: time.Now().Add(-time.Minute)}
+		resource := server.Resource{
+			Namespace:       randomString(),
+			Name:            randomString(),
+			Group:           randomString(),
+			Version:         randomString(),
+			Kind:            randomString(),
+			ProfileNames:    []string{randomString()},
+			LastAppliedTime: &time2,
+		}
+
+		resources = append(resources, resource)
+
+		sort.Slice(resources, func(i, j int) bool {
+			return server.SortResources(resources, i, j)
+		})
+
+		Expect(resources[0]).To(Equal(resource))
+
+		// Remove first element
+		resources = resources[1:]
+		for i := 0; i < len(resources)-2; i++ {
+			gvk1 := schema.GroupVersionKind{
+				Group:   resources[i].Group,
+				Kind:    resources[i].Kind,
+				Version: resources[i].Version,
+			}
+
+			gvk2 := schema.GroupVersionKind{
+				Group:   resources[i+1].Group,
+				Kind:    resources[i+1].Kind,
+				Version: resources[i+1].Version,
+			}
+
+			Expect(gvk1.String() < gvk2.String()).To(BeTrue())
+		}
+	})
+
+	It("sortHelmCharts sorts Helm Charts by applied time first and namespace/release name then", func() {
+		time1 := metav1.Time{Time: time.Now()}
+		helmReleases := make([]server.HelmRelease, 0)
+		for i := 0; i < 5; i++ {
+			helmRelease := server.HelmRelease{
+				Namespace:       randomString(),
+				ReleaseName:     randomString(),
+				RepoURL:         randomString(),
+				Icon:            randomString(),
+				ChartVersion:    randomString(),
+				ProfileName:     randomString(),
+				LastAppliedTime: &time1,
+			}
+
+			helmReleases = append(helmReleases, helmRelease)
+		}
+
+		time2 := metav1.Time{Time: time.Now().Add(-time.Minute)}
+		helmRelease := server.HelmRelease{
+			Namespace:       randomString(),
+			ReleaseName:     randomString(),
+			RepoURL:         randomString(),
+			Icon:            randomString(),
+			ChartVersion:    randomString(),
+			ProfileName:     randomString(),
+			LastAppliedTime: &time2,
+		}
+
+		helmReleases = append(helmReleases, helmRelease)
+
+		sort.Slice(helmReleases, func(i, j int) bool {
+			return server.SortHelmCharts(helmReleases, i, j)
+		})
+
+		Expect(helmReleases[0]).To(Equal(helmRelease))
+
+		// Remove first element
+		helmReleases = helmReleases[1:]
+		for i := 0; i < len(helmReleases)-2; i++ {
+			if helmReleases[i].Namespace == helmReleases[i+1].Namespace {
+				Expect(helmReleases[i].ReleaseName < helmReleases[i+1].ReleaseName)
+			}
+
+			Expect(helmReleases[i].Namespace < helmReleases[i+1].Namespace).To(BeTrue())
+		}
 	})
 })

--- a/internal/server/export_test.go
+++ b/internal/server/export_test.go
@@ -20,6 +20,9 @@ var (
 	GetClustersInRange    = getClustersInRange
 	GetHelmReleaseInRange = getHelmReleaseInRange
 	GetResourcesInRange   = getResourcesInRange
+
+	SortResources  = sortResources
+	SortHelmCharts = sortHelmCharts
 )
 
 var (

--- a/internal/server/http.go
+++ b/internal/server/http.go
@@ -122,7 +122,7 @@ var (
 			_ = c.AbortWithError(http.StatusBadRequest, err)
 		}
 		sort.Slice(helmCharts, func(i, j int) bool {
-			return helmCharts[i].LastAppliedTime.Before(helmCharts[j].LastAppliedTime)
+			return sortHelmCharts(helmCharts, i, j)
 		})
 
 		result, err := getHelmReleaseInRange(helmCharts, limit, skip)
@@ -156,7 +156,7 @@ var (
 			_ = c.AbortWithError(http.StatusBadRequest, err)
 		}
 		sort.Slice(resources, func(i, j int) bool {
-			return resources[i].LastAppliedTime.Before(resources[j].LastAppliedTime)
+			return sortResources(resources, i, j)
 		})
 
 		result, err := getResourcesInRange(resources, limit, skip)

--- a/manifest/manifest.yaml
+++ b/manifest/manifest.yaml
@@ -66,6 +66,22 @@ rules:
   - list
   - watch
 - apiGroups:
+  - config.projectsveltos.io
+  resources:
+  - clustersummaries
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - config.projectsveltos.io
+  resources:
+  - clustersummaries/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - lib.projectsveltos.io
   resources:
   - debuggingconfigurations


### PR DESCRIPTION
- Sort resources by lastAppliedTime first. In case of tie, use GroupVersionKind to sort
- Sort helm charts by lastAppliedTime first. In case of tie, use release namespace and release name.

Grant permissions to watch/get/list clusterSummary and ClusterSummary.Status