### PR TITLE
getClusterStatus

### DIFF
--- a/internal/server/manager.go
+++ b/internal/server/manager.go
@@ -39,10 +39,11 @@ type ClusterInfo struct {
 }
 
 type ClusterProfileStatus struct {
-	Name        *string                        `json:"name"`
-	Namespace   *string                        `json:"namespace"`
+	ProfileName string                         `json:"profileName"`
+	ProfileType string                         `json:"profileType"`
+	Namespace   string                         `json:"namespace"`
 	ClusterType libsveltosv1alpha1.ClusterType `json:"clusterType"`
-	ClusterName *string                        `json:"clusterName"`
+	ClusterName string                         `json:"clusterName"`
 	Summary     []ClusterFeatureSummary        `json:"summary"`
 }
 
@@ -64,13 +65,8 @@ type instance struct {
 }
 
 var (
-	managerInstance            *instance
-	lock                       = &sync.RWMutex{}
-	failingClusterSummaryTypes = []configv1alpha1.FeatureStatus{
-		configv1alpha1.FeatureStatusFailed,
-		configv1alpha1.FeatureStatusFailedNonRetriable,
-		configv1alpha1.FeatureStatusProvisioning,
-	}
+	managerInstance *instance
+	lock            = &sync.RWMutex{}
 )
 
 // InitializeManagerInstance initializes manager instance
@@ -131,10 +127,10 @@ func (m *instance) GetClusterProfileStatusesByCluster(
 	clusterProfileStatuses := make([]ClusterProfileStatus, 0)
 	for _, clusterProfileStatus := range m.clusterSummaryReport {
 		// since we're sure it is a proper cluster summary => we're sure it has this label
-		if *clusterProfileStatus.Namespace == *clusterNamespace && *clusterProfileStatus.ClusterName == *clusterName {
-			if clusterProfileStatus.ClusterType == clusterType {
-				clusterProfileStatuses = append(clusterProfileStatuses, clusterProfileStatus)
-			}
+		if clusterProfileStatus.Namespace == *clusterNamespace && clusterProfileStatus.ClusterName == *clusterName &&
+			clusterProfileStatus.ClusterType == clusterType {
+
+			clusterProfileStatuses = append(clusterProfileStatuses, clusterProfileStatus)
 		}
 	}
 
@@ -219,10 +215,11 @@ func (m *instance) AddClusterProfileStatus(summary *configv1alpha1.ClusterSummar
 	clusterFeatureSummaries := MapToClusterFeatureSummaries(&summary.Status.FeatureSummaries)
 
 	clusterProfileStatus := ClusterProfileStatus{
-		Name:        &profileOwnerRef.Name,
-		Namespace:   &summary.Namespace,
+		ProfileName: profileOwnerRef.Name,
+		ProfileType: profileOwnerRef.Kind,
+		Namespace:   summary.Namespace,
 		ClusterType: summary.Spec.ClusterType,
-		ClusterName: &summary.Spec.ClusterName,
+		ClusterName: summary.Spec.ClusterName,
 		Summary:     clusterFeatureSummaries,
 	}
 

--- a/internal/server/manager_test.go
+++ b/internal/server/manager_test.go
@@ -305,10 +305,11 @@ var _ = Describe("Manager", func() {
 		}
 
 		properClusterProfileStatus := server.ClusterProfileStatus{
-			Name:        &properClusterSummary.Name,
-			Namespace:   &properClusterSummary.Namespace,
+			ProfileName: properClusterSummary.Name,
+			ProfileType: configv1alpha1.ClusterProfileKind,
+			Namespace:   properClusterSummary.Namespace,
 			ClusterType: libsveltosv1alpha1.ClusterTypeCapi,
-			ClusterName: &properClusterSummary.Spec.ClusterName,
+			ClusterName: properClusterSummary.Spec.ClusterName,
 			Summary:     server.MapToClusterFeatureSummaries(&properClusterSummary.Status.FeatureSummaries),
 		}
 
@@ -392,6 +393,6 @@ var _ = Describe("Manager", func() {
 		// the remaining cluster profile must be the one specified by the proper cluster summary
 		// as it is the only one that belongs to the cluster with Namespace cluster.Namespace and
 		// Name cluster.Name
-		Expect(*clusterProfileStatuses[0].Name == properClusterSummary.Name).To(BeTrue())
+		Expect(clusterProfileStatuses[0].ProfileName == properClusterSummary.Name).To(BeTrue())
 	})
 })


### PR DESCRIPTION
This API returns Profile/ClusterProfile instances matching a cluster and the status of each feature.

This PR simply changes the return value by flattening it first as requested by UI.

This is an example of returned value:

```
{"profiles":[{"profileName":"deploy-kyverno","profileType":"ClusterProfile","featureID":"Helm","status":"Provisioned"},{"profileName":"deploy-resources","profileType":"ClusterProfile","featureID":"Resources","status":"Provisioned"},{"profileName":"nginx","profileType":"ClusterProfile","featureID":"Helm","status":"Provisioned"}],"totalResources":3}
```

Results are ordered by:
1. Profile Type (ClusterProfiles before Profiles)
2. Profile Name
3. Feature ID