### PR TITLE
Add API to get detailed profile info

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,28 @@ Each profile contains:
     dependents: []
 ```
 
+### Get a profile instance
+
+```/profile?namespace=<profile namespace>&name=<profile name>&kind<profile kind>```
+
+Kind can either be:
+- ClusterProfile
+- Profile
+
+ClusterProfiles are cluster wide resources. Profiles are namespaced resources. So namespace is *only* required for Profile.
+
+Response contains:
+
+- Kind: kind of the profile (ClusterProfile vs Profile)
+- Namespace: namespace of the profile (empty for ClusterProfiles)
+- Name: name of the profile
+- Dependencies: list of profiles the profile depends on
+- Dependents: list of profiles that depend on this profile
+- Spec: profile's spec
+- MatchingClusters: list of clusters matching this profile. This list contains *only* the clusters users has permission for.
+So if both coke and pepsi clusters are matching a profile, coke admin will only see coke clusters and pepsi admin will only
+see pepsi clusters. Platform admin will see both in the response.
+
 
 ### How to get token
 

--- a/internal/server/manager.go
+++ b/internal/server/manager.go
@@ -491,6 +491,13 @@ func (m *instance) RemoveProfile(profile *corev1.ObjectReference) {
 	delete(m.profiles, *profile)
 }
 
+func (m *instance) GetProfile(profile *corev1.ObjectReference) ProfileInfo {
+	m.profileMux.Lock()
+	defer m.profileMux.Unlock()
+
+	return m.profiles[*profile]
+}
+
 // removeProfileDependency removes oldDependency from source's cached dependents
 func (m *instance) removeProfileDependency(source, oldDependency *corev1.ObjectReference) {
 	profileInfo, ok := m.profiles[*source]

--- a/internal/server/profiles.go
+++ b/internal/server/profiles.go
@@ -19,6 +19,8 @@ package server
 import (
 	"github.com/gin-gonic/gin"
 	corev1 "k8s.io/api/core/v1"
+
+	configv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
 )
 
 type Profile struct {
@@ -32,6 +34,10 @@ type Profile struct {
 	Dependencies []corev1.ObjectReference `json:"dependencies"`
 	// List of profiles that depend on this profile
 	Dependents []corev1.ObjectReference `json:"dependents"`
+	// List of managed clusters matching this profile
+	MatchingClusters []corev1.ObjectReference `json:"matchingClusters"`
+	// Profile's Spec section
+	Spec configv1beta1.Spec `json:"spec"`
 }
 
 type Profiles []Profile
@@ -53,6 +59,7 @@ func (s Profiles) Less(i, j int) bool {
 type profileFilters struct {
 	Namespace string `uri:"namespace"`
 	Name      string `uri:"name"`
+	Kind      string `uri:"kind"`
 }
 
 func getProfileFiltersFromQuery(c *gin.Context) *profileFilters {
@@ -60,6 +67,7 @@ func getProfileFiltersFromQuery(c *gin.Context) *profileFilters {
 	// Get the values from query parameters
 	filters.Namespace = c.Query("namespace")
 	filters.Name = c.Query("name")
+	filters.Kind = c.Query("kind")
 
 	return &filters
 }


### PR DESCRIPTION
To get detailed info about a Profile

```
/profile?namespace=<profile namespace>&name=<profile name>&kind=Profile
```

To get detailed info about a ClusterProfile

```
/profile?name=<clusterprofile name>&kind=ClusterProfile
```

Response will contain:

- Kind: kind of the profile (ClusterProfile vs Profile)
- Namespace: namespace of the profile (empty for ClusterProfiles)
- Name: name of the profile
- Dependencies: list of profiles the profile depends on
- Dependents: list of profiles that depend on this profile
- MatchingClusters: list of clusters (ClusterAPI or SveltosCluster) matching the profile. this list contains *only* the clusters a user can see
- Spec: profile's spec

Here is an example:

```yaml
---
kind: "ClusterProfile"
namespace: ""
name: "prometheus-grafana"
dependencies:
- kind: "ClusterProfile"
  name: "deploy-kyverno"
  apiVersion: "config.projectsveltos.io/v1beta1"
dependents:
matchingClusters:
- kind: "Cluster"
  namespace: "default"
  name: "clusterapi-workload"
  apiVersion: "cluster.x-k8s.io/v1beta1"
spec:
  clusterSelector:
    matchLabels:
      env: "fv"
  syncMode: "Continuous"
  tier: "100"
  stopMatchingBehavior: "WithdrawPolicies"
  dependsOn:
  - "deploy-kyverno"
  helmCharts:
  - repositoryURL: "https://prometheus-community.github.io/helm-charts"
    repositoryName: "prometheus-community"
    chartName: "prometheus-community/prometheus"
    chartVersion: "23.4.0"
    releaseName: "prometheus"
    releaseNamespace: "prometheus"
    helmChartAction: "Install"
  - repositoryURL: "https://grafana.github.io/helm-charts"
    repositoryName: "grafana"
    chartName: "grafana/grafana"
    chartVersion: "6.58.9"
    releaseName: "grafana"
    releaseNamespace: "grafana"
    helmChartAction: "Install"
```