### PR TITLE
(feat) add Sveltos MCP client

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ ARCH ?= amd64
 OS ?= $(shell uname -s | tr A-Z a-z)
 K8S_LATEST_VER ?= $(shell curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)
 export CONTROLLER_IMG ?= $(REGISTRY)/$(IMAGE_NAME)
-TAG ?= v1.0.1
+TAG ?= main
 
 .PHONY: all
 all: build

--- a/config/default/manager_image_patch.yaml
+++ b/config/default/manager_image_patch.yaml
@@ -8,5 +8,5 @@ spec:
     spec:
       containers:
       # Change the value of image field below to your controller image URL
-      - image: projectsveltos/ui-backend:v1.0.1
+      - image: projectsveltos/ui-backend:main
         name: manager

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/fluxcd/source-controller/api v1.6.2
 	github.com/gin-gonic/gin v1.10.1
 	github.com/go-logr/logr v1.4.3
+	github.com/modelcontextprotocol/go-sdk v0.4.0
 	github.com/onsi/ginkgo/v2 v2.25.3
 	github.com/onsi/gomega v1.38.2
 	github.com/pkg/errors v0.9.1
@@ -62,6 +63,7 @@ require (
 	github.com/google/cel-go v0.26.1 // indirect
 	github.com/google/gnostic-models v0.7.0 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
+	github.com/google/jsonschema-go v0.2.1-0.20250825175020-748c325cec76 // indirect
 	github.com/google/pprof v0.0.0-20250820193118-f64d9cf942d6 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.26.3 // indirect
@@ -95,6 +97,7 @@ require (
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.2.12 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
+	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	github.com/yuin/gopher-lua v1.1.1 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.58.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -104,6 +104,8 @@ github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
 github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/jsonschema-go v0.2.1-0.20250825175020-748c325cec76 h1:mBlBwtDebdDYr+zdop8N62a44g+Nbv7o2KjWyS1deR4=
+github.com/google/jsonschema-go v0.2.1-0.20250825175020-748c325cec76/go.mod h1:r5quNTdLOYEz95Ru18zA0ydNbBuYoo9tgaYcxEYhJVE=
 github.com/google/pprof v0.0.0-20250820193118-f64d9cf942d6 h1:EEHtgt9IwisQ2AZ4pIsMjahcegHh6rmhqxzIRQIyepY=
 github.com/google/pprof v0.0.0-20250820193118-f64d9cf942d6/go.mod h1:I6V7YzU0XDpsHqbsyrghnFZLO1gwK6NPTNvmetQIk9U=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
@@ -142,6 +144,8 @@ github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa1
 github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HKCj9FbZEVFJRxO9s=
 github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
+github.com/modelcontextprotocol/go-sdk v0.4.0 h1:RJ6kFlneHqzTKPzlQqiunrz9nbudSZcYLmLHLsokfoU=
+github.com/modelcontextprotocol/go-sdk v0.4.0/go.mod h1:whv0wHnsTphwq7CTiKYHkLtwLC06WMoY2KpO+RB9yXQ=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -215,6 +219,8 @@ github.com/ugorji/go/codec v1.2.12 h1:9LC83zGrHhuUA9l16C9AHXAqEV/2wBQ4nkvumAE65E
 github.com/ugorji/go/codec v1.2.12/go.mod h1:UNopzCgEMSXjBc6AOMqYvWC1ktqTAfzJZUZgYf6w6lg=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
+github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
+github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=

--- a/internal/mcpclient/client.go
+++ b/internal/mcpclient/client.go
@@ -1,0 +1,299 @@
+/*
+Copyright 2025. projectsveltos.io. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mcpclient
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	corev1 "k8s.io/api/core/v1"
+
+	configv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
+	logs "github.com/projectsveltos/libsveltos/lib/logsettings"
+)
+
+const (
+	noStructureContentError = "tool returned no structured content"
+)
+
+// connect to Sveltos mcp server
+func connect(ctx context.Context, url string, logger logr.Logger) (*mcp.ClientSession, error) {
+	// Create the URL for the server.
+	logger.V(logs.LogInfo).Info(fmt.Sprintf("Connecting to MCP server at %s", url))
+
+	// Create an MCP client.
+	client := mcp.NewClient(&mcp.Implementation{
+		Name:    "sveltos-client",
+		Version: "1.0.0",
+	}, nil)
+
+	// Connect to the server.
+	session, err := client.Connect(ctx, &mcp.StreamableClientTransport{Endpoint: url}, nil)
+	if err != nil {
+		logger.V(logs.LogInfo).Info(fmt.Sprintf("failed to connect: %v", err))
+		return nil, err
+	}
+
+	logger.V(logs.LogDebug).Info(fmt.Sprintf("Connected to server (session ID: %s)", session.ID()))
+
+	// First, list available tools.
+	logger.V(logs.LogDebug).Info("Listing available tools...")
+	toolsResult, err := session.ListTools(ctx, nil)
+	if err != nil {
+		logger.V(logs.LogInfo).Info(fmt.Sprintf("failed to list tool: %v", err))
+		return nil, err
+	}
+
+	for _, tool := range toolsResult.Tools {
+		logger.V(logs.LogInfo).Info(fmt.Sprintf("  - %s: %s\n", tool.Name, tool.Description))
+	}
+
+	return session, nil
+}
+
+// SveltosInstallationResult reports the outcome of the Sveltos installation verification.
+type SveltosInstallationResult struct {
+	IsCorrectlyInstalled bool   `json:"is_correctly_installed"`
+	Details              string `json:"details,omitempty"`
+}
+
+func CheckInstallation(ctx context.Context, url string, logger logr.Logger) (string, error) {
+	session, err := connect(ctx, url, logger)
+	if err != nil {
+		logger.V(logs.LogInfo).Info(fmt.Sprintf("failed to connect: %v", err))
+		return "", err
+	}
+	defer session.Close()
+
+	result, err := session.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "installation_status",
+		Arguments: nil,
+	})
+
+	if err != nil {
+		logger.V(logs.LogInfo).Info(fmt.Sprintf("failed to invoked installation_status tool: %v", err))
+		return "", err
+	}
+
+	if result.IsError {
+		errorMsg := fmt.Sprintf("MCP installation_status returned error: %v", result.Content)
+		logger.V(logs.LogInfo).Info(errorMsg)
+		return "", errors.New(errorMsg)
+	}
+
+	// Check for structured content. It should contain our result.
+	if result.StructuredContent == nil {
+		errorMsg := noStructureContentError
+		logger.V(logs.LogInfo).Info(errorMsg)
+		return "", errors.New(errorMsg)
+	}
+
+	// Marshal the StructuredContent to JSON and then unmarshal it into our struct.
+	// This is a common pattern for converting `any` to a specific type.
+	data, err := json.Marshal(result.StructuredContent)
+	if err != nil {
+		errorMsg := fmt.Sprintf("failed to marshal structured content: %v", err)
+		logger.V(logs.LogInfo).Info(errorMsg)
+		return "", errors.New(errorMsg)
+	}
+
+	var installationResult SveltosInstallationResult
+	err = json.Unmarshal(data, &installationResult)
+	if err != nil {
+		return "", fmt.Errorf("failed to unmarshal structured content: %w", err)
+	}
+
+	logger.V(logs.LogInfo).Info(fmt.Sprintf("installation_status result: %v", installationResult))
+
+	// Check the boolean field from the unmarshaled struct to get the result.
+	if installationResult.IsCorrectlyInstalled {
+		return "Sveltos installation is correct.", nil
+	}
+
+	return fmt.Sprintf("Sveltos installation is NOT correct. Details: %s", installationResult.Details), nil
+}
+
+// DeploymentError represents a single deployment failure for a Sveltos profile.
+type DeploymentError struct {
+	ProfileName string `json:"profileName" jsonschema:"The name of the Sveltos profile that is failing"`
+	ProfileKind string `json:"profileKind" jsonschema:"The profile kind (ClusterProfile vs Profile)"`
+	Cause       string `json:"cause" jsonschema:"The reason for the deployment failure"`
+}
+
+func CheckProfileDeploymentOnCluster(ctx context.Context, url string, clusterRef,
+	profileRef *corev1.ObjectReference, logger logr.Logger) (string, error) {
+
+	session, err := connect(ctx, url, logger)
+	if err != nil {
+		logger.V(logs.LogInfo).Info(fmt.Sprintf("failed to connect: %v", err))
+		return "", err
+	}
+	defer session.Close()
+
+	input := map[string]any{
+		"clusterRef": map[string]any{
+			"namespace":  clusterRef.Namespace,
+			"name":       clusterRef.Name,
+			"kind":       clusterRef.Kind,
+			"apiVersion": clusterRef.APIVersion,
+		},
+		"profileRef": map[string]any{
+			"namespace":  profileRef.Namespace,
+			"name":       profileRef.Name,
+			"kind":       profileRef.Kind,
+			"apiVersion": profileRef.APIVersion,
+		},
+	}
+
+	result, err := session.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "analyze_profile_deployment",
+		Arguments: input,
+	})
+
+	if err != nil {
+		logger.V(logs.LogInfo).Info(fmt.Sprintf("failed to invoked analyze_profile_deployment tool: %v", err))
+		return "", err
+	}
+
+	if result.IsError {
+		errorMsg := fmt.Sprintf("MCP analyze_profile_deployment returned error: %v", result.Content)
+		logger.V(logs.LogInfo).Info(errorMsg)
+		return "", errors.New(errorMsg)
+	}
+
+	// Check for structured content. It should contain our result.
+	if result.StructuredContent == nil {
+		errorMsg := noStructureContentError
+		logger.V(logs.LogInfo).Info(errorMsg)
+		return "", errors.New(errorMsg)
+	}
+
+	// Marshal the StructuredContent to JSON and then unmarshal it into our struct.
+	// This is a common pattern for converting `any` to a specific type.
+	data, err := json.Marshal(result.StructuredContent)
+	if err != nil {
+		errorMsg := fmt.Sprintf("failed to marshal structured content: %v", err)
+		logger.V(logs.LogInfo).Info(errorMsg)
+		return "", errors.New(errorMsg)
+	}
+
+	var deploymentResult DeploymentError
+	err = json.Unmarshal(data, &deploymentResult)
+	if err != nil {
+		return "", fmt.Errorf("failed to unmarshal structured content: %w", err)
+	}
+
+	logger.V(logs.LogInfo).Info(fmt.Sprintf("analyze_profile_deployment result: %v", deploymentResult))
+
+	profileName := profileRef.Name
+	if profileRef.Kind == configv1beta1.ProfileKind {
+		profileName = fmt.Sprintf("%s/%s", profileRef.Namespace, profileRef.Name)
+	}
+
+	// Check the boolean field from the unmarshaled struct to get the result.
+	if deploymentResult.Cause == "" {
+		return fmt.Sprintf("%s %s is properly deployed on Cluster %s %s/%s",
+			profileRef.Kind, profileName,
+			clusterRef.Kind, clusterRef.Namespace, clusterRef.Namespace), nil
+	}
+
+	return fmt.Sprintf("%s %s is not properly deployed on Cluster %s %s/%s. Following errors detected: %s",
+		profileRef.Kind, profileName,
+		clusterRef.Kind, clusterRef.Namespace, clusterRef.Namespace,
+		deploymentResult.Cause), nil
+}
+
+type DeploymentErrors struct {
+	Errors []DeploymentError `json:"deploymentErrors" jsonschema:"List of all resources that are being deployed, failing to deploy or whose deployment has failed"`
+}
+
+func CheckClusterDeploymentStatuses(ctx context.Context, url string, clusterRef *corev1.ObjectReference,
+	logger logr.Logger) (string, error) {
+
+	session, err := connect(ctx, url, logger)
+	if err != nil {
+		logger.V(logs.LogInfo).Info(fmt.Sprintf("failed to connect: %v", err))
+		return "", err
+	}
+	defer session.Close()
+
+	input := map[string]any{
+		"namespace":  clusterRef.Namespace,
+		"name":       clusterRef.Name,
+		"kind":       clusterRef.Kind,
+		"apiVersion": clusterRef.APIVersion,
+	}
+
+	result, err := session.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "list_deployement_errors",
+		Arguments: input,
+	})
+
+	if err != nil {
+		logger.V(logs.LogInfo).Info(fmt.Sprintf("failed to invoked list_deployement_errors tool: %v", err))
+		return "", err
+	}
+
+	if result.IsError {
+		errorMsg := fmt.Sprintf("MCP list_deployement_errors returned error: %v", result.Content)
+		logger.V(logs.LogInfo).Info(errorMsg)
+		return "", errors.New(errorMsg)
+	}
+
+	// Check for structured content. It should contain our result.
+	if result.StructuredContent == nil {
+		errorMsg := noStructureContentError
+		logger.V(logs.LogInfo).Info(errorMsg)
+		return "", errors.New(errorMsg)
+	}
+
+	// Marshal the StructuredContent to JSON and then unmarshal it into our struct.
+	// This is a common pattern for converting `any` to a specific type.
+	data, err := json.Marshal(result.StructuredContent)
+	if err != nil {
+		errorMsg := fmt.Sprintf("failed to marshal structured content: %v", err)
+		logger.V(logs.LogInfo).Info(errorMsg)
+		return "", errors.New(errorMsg)
+	}
+
+	var deploymentResult DeploymentErrors
+	err = json.Unmarshal(data, &deploymentResult)
+	if err != nil {
+		return "", fmt.Errorf("failed to unmarshal structured content: %w", err)
+	}
+
+	logger.V(logs.LogInfo).Info(fmt.Sprintf("analyze_profile_deployment result: %v", deploymentResult))
+
+	if len(deploymentResult.Errors) == 0 {
+		return fmt.Sprintf("all matching profiles are successfully deployed on cluster %s %s/%s",
+			clusterRef.Kind, clusterRef.Namespace, clusterRef.Namespace), nil
+	}
+
+	detectedErrors := ""
+
+	for i := range deploymentResult.Errors {
+		detectedErrors += fmt.Sprintf("%s %s is not properly deployed. Following errors detected: %s",
+			deploymentResult.Errors[i].ProfileKind, deploymentResult.Errors[i].ProfileName,
+			deploymentResult.Errors[i].Cause)
+	}
+
+	return detectedErrors, nil
+}

--- a/manifest/manifest.yaml
+++ b/manifest/manifest.yaml
@@ -140,7 +140,7 @@ spec:
         - --v=5
         command:
         - /manager
-        image: projectsveltos/ui-backend:v1.0.1
+        image: projectsveltos/ui-backend:main
         livenessProbe:
           failureThreshold: 3
           httpGet:


### PR DESCRIPTION
1. `/installation` calls MCP tool **installation_status** which returns any error with Sveltos installation

2. `/debugCluster?namespace=default&name=clusterapi-workload&type=capi` requires namespace (cluster namespace), name (cluster name) and type (cluster type either capi or sveltos). Calls the MCP tool **list_deployement_errors** which reports any profile deployment error on a given cluster.

3. `debugProfileCluster?namespace=default&clusterName=clusterapi-workload&clusterType=capi&profileName=deploy-kyverno1&profileKind=ClusterProfile'` requires namespace (cluster namespace), clusterName and clusterType (either capi or sveltos) and profileName/profileKind. It calls the MCP tool **analyze_profile_deployment** which reports any error regarding the deployment of the specified profile on the specified cluster.