### PR TITLE
Add /stats API

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,6 +481,36 @@ When the controller has not yet generated a ClusterReport for the profile+cluste
 }
 ```
 
+### Get Sveltos Stats
+
+```/stats```
+
+Returns counts of Sveltos resources accessible to the requesting user. No query parameters are required.
+
+Response fields:
+
+- `capiClusters` — total number of accessible ClusterAPI powered clusters
+- `notReadyCAPIClusters` — number of CAPI clusters whose control plane is not yet initialized
+- `sveltosClusters` — total number of accessible SveltosClusters
+- `notReadySveltosClusters` — number of SveltosClusters that are not ready
+- `pullModeClusters` — number of SveltosClusters running in pull mode (agent-based)
+- `clusterProfiles` — number of accessible ClusterProfiles
+- `profiles` — number of accessible Profiles
+- `clusterSummaries` — number of accessible ClusterSummaries (one per profile+cluster pair)
+- `eventTriggers` — number of accessible EventTriggers
+
+Each count reflects only the resources the authenticated user has permission to view.
+
+```
+http://localhost:9000/stats
+```
+
+returns
+
+```json
+{"capiClusters":1,"notReadyCAPIClusters":0,"sveltosClusters":1,"notReadySveltosClusters":0,"pullModeClusters":0,"clusterProfiles":12,"profiles":0,"clusterSummaries":11,"eventTriggers":1}
+```
+
 ### Get list of EventTriggers
 
 ```/events```

--- a/internal/server/export_test.go
+++ b/internal/server/export_test.go
@@ -16,6 +16,72 @@ limitations under the License.
 
 package server
 
+import (
+	"context"
+
+	configv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
+)
+
+// Accessors for the private clusterCounts struct, used by external test packages.
+func (cc clusterCounts) CAPITotal() int       { return cc.capiTotal }
+func (cc clusterCounts) CAPINotReady() int    { return cc.capiNotReady }
+func (cc clusterCounts) SveltosTotal() int    { return cc.sveltosTotal }
+func (cc clusterCounts) SveltosNotReady() int { return cc.sveltosNotReady }
+func (cc clusterCounts) PullMode() int        { return cc.pullMode }
+
+// CountClusters is a test helper that bypasses SAR by accepting explicit canList booleans.
+func (m *instance) CountClusters(ctx context.Context, canListSveltos, canListCAPI bool, user string) (clusterCounts, error) {
+	sveltos, err := m.GetManagedSveltosClusters(ctx, canListSveltos, user)
+	if err != nil {
+		return clusterCounts{}, err
+	}
+	capi, err := m.GetManagedCAPIClusters(ctx, canListCAPI, user)
+	if err != nil {
+		return clusterCounts{}, err
+	}
+
+	cc := clusterCounts{
+		capiTotal:    len(capi),
+		sveltosTotal: len(sveltos),
+	}
+	for _, info := range capi {
+		if !info.Ready {
+			cc.capiNotReady++
+		}
+	}
+	for _, info := range sveltos {
+		if !info.Ready {
+			cc.sveltosNotReady++
+		}
+		if info.PullMode {
+			cc.pullMode++
+		}
+	}
+	return cc, nil
+}
+
+// CountProfilesByKind is a test helper that bypasses SAR by accepting explicit canList booleans.
+func (m *instance) CountProfilesByKind(ctx context.Context, canListCP, canListP bool, user string) (clusterProfiles, profiles int, err error) {
+	accessible, err := m.GetProfiles(ctx, canListCP, canListP, user)
+	if err != nil {
+		return 0, 0, err
+	}
+	for ref := range accessible {
+		switch ref.Kind {
+		case configv1beta1.ClusterProfileKind:
+			clusterProfiles++
+		case configv1beta1.ProfileKind:
+			profiles++
+		}
+	}
+	return clusterProfiles, profiles, nil
+}
+
+// CountClusterSummaries returns the number of ClusterSummaries in the in-memory cache.
+func (m *instance) CountClusterSummaries() int {
+	return len(m.GetClusterProfileStatuses())
+}
+
 var (
 	GetClustersInRange    = getClustersInRange
 	GetHelmReleaseInRange = getHelmReleaseInRange

--- a/internal/server/http.go
+++ b/internal/server/http.go
@@ -963,6 +963,27 @@ var (
 
 		c.JSON(http.StatusOK, result)
 	}
+
+	getStats = func(c *gin.Context) {
+		ginLogger.V(logs.LogDebug).Info("get Sveltos stats")
+
+		user, err := validateToken(c)
+		if err != nil {
+			_ = c.AbortWithError(http.StatusUnauthorized, err)
+			return
+		}
+
+		manager := GetManagerInstance()
+
+		stats, err := manager.getSveltosStats(c.Request.Context(), user)
+		if err != nil {
+			ginLogger.V(logs.LogInfo).Info(fmt.Sprintf("failed to get stats %s: %v", c.Request.URL, err))
+			_ = c.AbortWithError(http.StatusInternalServerError, err)
+			return
+		}
+
+		c.JSON(http.StatusOK, stats)
+	}
 )
 
 func (m *instance) start(ctx context.Context, port string, logger logr.Logger) {
@@ -991,6 +1012,8 @@ func (m *instance) start(ctx context.Context, port string, logger logr.Logger) {
 	r.GET("/events", getEvents)
 	// Return details about a specific EventTrigger
 	r.GET("/event", getEvent)
+	// Return counts of Sveltos resources accessible to the user
+	r.GET("/stats", getStats)
 
 	// MCP tools
 	// Return details about Sveltos installation

--- a/internal/server/k8s-utils.go
+++ b/internal/server/k8s-utils.go
@@ -437,3 +437,93 @@ func (m *instance) getProfileSpecAndMatchingClusters(ctx context.Context, profil
 
 	return &spec, accessibleMatchingClusters, nil
 }
+
+// canListClusterSummaries verifies whether user has permission to list ClusterSummaries
+func (m *instance) canListClusterSummaries(user string) (bool, error) {
+	clientset, err := kubernetes.NewForConfig(m.config)
+	if err != nil {
+		m.logger.V(logs.LogInfo).Info(fmt.Sprintf("failed to get clientset: %v", err))
+		return false, err
+	}
+
+	sar := &authorizationapi.SubjectAccessReview{
+		Spec: authorizationapi.SubjectAccessReviewSpec{
+			ResourceAttributes: &authorizationapi.ResourceAttributes{
+				Verb:     "list",
+				Group:    configv1beta1.GroupVersion.Group,
+				Version:  configv1beta1.GroupVersion.Version,
+				Resource: configv1beta1.ClusterSummaryKind,
+			},
+			User: user,
+		},
+	}
+
+	canI, err := clientset.AuthorizationV1().SubjectAccessReviews().Create(context.TODO(), sar, metav1.CreateOptions{})
+	if err != nil {
+		m.logger.V(logs.LogInfo).Info(fmt.Sprintf("failed to check clientset permissions: %v", err))
+		return false, err
+	}
+
+	return canI.Status.Allowed, nil
+}
+
+// canGetClusterSummary returns true if user can access ClusterSummary namespace/name
+func (m *instance) canGetClusterSummary(namespace, name, user string) (bool, error) {
+	clientset, err := kubernetes.NewForConfig(m.config)
+	if err != nil {
+		m.logger.V(logs.LogInfo).Info(fmt.Sprintf("failed to get clientset: %v", err))
+		return false, err
+	}
+
+	sar := &authorizationapi.SubjectAccessReview{
+		Spec: authorizationapi.SubjectAccessReviewSpec{
+			ResourceAttributes: &authorizationapi.ResourceAttributes{
+				Verb:      "get",
+				Group:     configv1beta1.GroupVersion.Group,
+				Version:   configv1beta1.GroupVersion.Version,
+				Resource:  configv1beta1.ClusterSummaryKind,
+				Namespace: namespace,
+				Name:      name,
+			},
+			User: user,
+		},
+	}
+
+	canI, err := clientset.AuthorizationV1().SubjectAccessReviews().Create(context.TODO(), sar, metav1.CreateOptions{})
+	if err != nil {
+		m.logger.V(logs.LogInfo).Info(fmt.Sprintf("failed to check clientset permissions: %v", err))
+		return false, err
+	}
+
+	return canI.Status.Allowed, nil
+}
+
+// canGetEventTrigger returns true if user can access EventTrigger name
+func (m *instance) canGetEventTrigger(name, user string) (bool, error) {
+	clientset, err := kubernetes.NewForConfig(m.config)
+	if err != nil {
+		m.logger.V(logs.LogInfo).Info(fmt.Sprintf("failed to get clientset: %v", err))
+		return false, err
+	}
+
+	sar := &authorizationapi.SubjectAccessReview{
+		Spec: authorizationapi.SubjectAccessReviewSpec{
+			ResourceAttributes: &authorizationapi.ResourceAttributes{
+				Verb:     "get",
+				Group:    eventv1beta1.GroupVersion.Group,
+				Version:  eventv1beta1.GroupVersion.Version,
+				Resource: eventv1beta1.EventTriggerKind,
+				Name:     name,
+			},
+			User: user,
+		},
+	}
+
+	canI, err := clientset.AuthorizationV1().SubjectAccessReviews().Create(context.TODO(), sar, metav1.CreateOptions{})
+	if err != nil {
+		m.logger.V(logs.LogInfo).Info(fmt.Sprintf("failed to check clientset permissions: %v", err))
+		return false, err
+	}
+
+	return canI.Status.Allowed, nil
+}

--- a/internal/server/stats.go
+++ b/internal/server/stats.go
@@ -1,0 +1,213 @@
+/*
+Copyright 2026. projectsveltos.io. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server
+
+import (
+	"context"
+	"fmt"
+
+	configv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
+	eventv1beta1 "github.com/projectsveltos/event-manager/api/v1beta1"
+	logs "github.com/projectsveltos/libsveltos/lib/logsettings"
+)
+
+// Stats holds counts of Sveltos resources accessible to the requesting user.
+type Stats struct {
+	CAPIClusters            int `json:"capiClusters"`
+	NotReadyCAPIClusters    int `json:"notReadyCAPIClusters"`
+	SveltosClusters         int `json:"sveltosClusters"`
+	NotReadySveltosClusters int `json:"notReadySveltosClusters"`
+	PullModeClusters        int `json:"pullModeClusters"`
+	ClusterProfiles         int `json:"clusterProfiles"`
+	Profiles                int `json:"profiles"`
+	ClusterSummaries        int `json:"clusterSummaries"`
+	EventTriggers           int `json:"eventTriggers"`
+}
+
+type clusterCounts struct {
+	capiTotal       int
+	capiNotReady    int
+	sveltosTotal    int
+	sveltosNotReady int
+	pullMode        int
+}
+
+func (m *instance) getSveltosStats(ctx context.Context, user string) (Stats, error) {
+	cc, err := m.countClusters(ctx, user)
+	if err != nil {
+		return Stats{}, err
+	}
+
+	clusterProfiles, profiles, err := m.countClusterProfilesAndProfiles(ctx, user)
+	if err != nil {
+		return Stats{}, err
+	}
+
+	clusterSummaries, err := m.countClusterSummaries(ctx, user)
+	if err != nil {
+		return Stats{}, err
+	}
+
+	eventTriggers, err := m.countEventTriggers(ctx, user)
+	if err != nil {
+		return Stats{}, err
+	}
+
+	return Stats{
+		CAPIClusters:            cc.capiTotal,
+		NotReadyCAPIClusters:    cc.capiNotReady,
+		SveltosClusters:         cc.sveltosTotal,
+		NotReadySveltosClusters: cc.sveltosNotReady,
+		PullModeClusters:        cc.pullMode,
+		ClusterProfiles:         clusterProfiles,
+		Profiles:                profiles,
+		ClusterSummaries:        clusterSummaries,
+		EventTriggers:           eventTriggers,
+	}, nil
+}
+
+func (m *instance) countClusters(ctx context.Context, user string) (clusterCounts, error) {
+	canListSveltos, err := m.canListSveltosClusters(user)
+	if err != nil {
+		return clusterCounts{}, err
+	}
+	canListCAPI, err := m.canListCAPIClusters(user)
+	if err != nil {
+		return clusterCounts{}, err
+	}
+
+	sveltos, err := m.GetManagedSveltosClusters(ctx, canListSveltos, user)
+	if err != nil {
+		return clusterCounts{}, err
+	}
+	capi, err := m.GetManagedCAPIClusters(ctx, canListCAPI, user)
+	if err != nil {
+		return clusterCounts{}, err
+	}
+
+	cc := clusterCounts{
+		capiTotal:    len(capi),
+		sveltosTotal: len(sveltos),
+	}
+	for _, info := range capi {
+		if !info.Ready {
+			cc.capiNotReady++
+		}
+	}
+	for _, info := range sveltos {
+		if !info.Ready {
+			cc.sveltosNotReady++
+		}
+		if info.PullMode {
+			cc.pullMode++
+		}
+	}
+
+	return cc, nil
+}
+
+func (m *instance) countClusterProfilesAndProfiles(ctx context.Context, user string) (clusterProfiles, profiles int, err error) {
+	canListCP, err := m.canListClusterProfiles(user)
+	if err != nil {
+		return 0, 0, err
+	}
+	canListP, err := m.canListProfiles(user)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	accessible, err := m.GetProfiles(ctx, canListCP, canListP, user)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	for ref := range accessible {
+		switch ref.Kind {
+		case configv1beta1.ClusterProfileKind:
+			clusterProfiles++
+		case configv1beta1.ProfileKind:
+			profiles++
+		}
+	}
+
+	return clusterProfiles, profiles, nil
+}
+
+func (m *instance) countClusterSummaries(ctx context.Context, user string) (int, error) {
+	canList, err := m.canListClusterSummaries(user)
+	if err != nil {
+		return 0, err
+	}
+
+	if canList {
+		m.clusterStatusesMux.RLock()
+		defer m.clusterStatusesMux.RUnlock()
+		return len(m.clusterSummaryReport), nil
+	}
+
+	summaries := &configv1beta1.ClusterSummaryList{}
+	if err := m.client.List(ctx, summaries); err != nil {
+		m.logger.V(logs.LogInfo).Info(fmt.Sprintf("failed to list ClusterSummaries: %v", err))
+		return 0, err
+	}
+
+	count := 0
+	for i := range summaries.Items {
+		s := &summaries.Items[i]
+		ok, err := m.canGetClusterSummary(s.Namespace, s.Name, user)
+		if err != nil {
+			continue
+		}
+		if ok {
+			count++
+		}
+	}
+	return count, nil
+}
+
+func (m *instance) countEventTriggers(ctx context.Context, user string) (int, error) {
+	canList, err := m.canListEventTriggers(user)
+	if err != nil {
+		return 0, err
+	}
+
+	eventTriggers := &eventv1beta1.EventTriggerList{}
+	if err := m.client.List(ctx, eventTriggers); err != nil {
+		m.logger.V(logs.LogInfo).Info(fmt.Sprintf("failed to list EventTriggers: %v", err))
+		return 0, err
+	}
+
+	count := 0
+	for i := range eventTriggers.Items {
+		et := &eventTriggers.Items[i]
+		if !et.GetDeletionTimestamp().IsZero() {
+			continue
+		}
+		if canList {
+			count++
+			continue
+		}
+		ok, err := m.canGetEventTrigger(et.Name, user)
+		if err != nil {
+			continue
+		}
+		if ok {
+			count++
+		}
+	}
+	return count, nil
+}

--- a/internal/server/stats_test.go
+++ b/internal/server/stats_test.go
@@ -1,0 +1,319 @@
+/*
+Copyright 2025. projectsveltos.io. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/klog/v2/textlogger"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	configv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
+	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
+	"github.com/projectsveltos/ui-backend/internal/server"
+)
+
+var _ = Describe("Stats", func() {
+	var c client.Client
+	var logger logr.Logger
+	var sc *runtime.Scheme
+
+	BeforeEach(func() {
+		var err error
+		sc, err = setupScheme()
+		Expect(err).To(BeNil())
+		logger = textlogger.NewLogger(textlogger.NewConfig())
+	})
+
+	It("CountClusters returns separate CAPI and Sveltos totals", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		server.InitializeManagerInstance(ctx, nil, c, sc, randomPort(), logger)
+		manager := server.GetManagerInstance()
+
+		initial, err := manager.CountClusters(ctx, true, true, randomString())
+		Expect(err).To(BeNil())
+
+		sc1 := &libsveltosv1beta1.SveltosCluster{
+			ObjectMeta: metav1.ObjectMeta{Namespace: randomString(), Name: randomString()},
+			Status:     libsveltosv1beta1.SveltosClusterStatus{Ready: true},
+		}
+		sc2 := &libsveltosv1beta1.SveltosCluster{
+			ObjectMeta: metav1.ObjectMeta{Namespace: randomString(), Name: randomString()},
+		}
+		capiCluster := createTestCAPICluster(randomString(), randomString())
+
+		manager.AddSveltosCluster(sc1)
+		manager.AddSveltosCluster(sc2)
+		manager.AddCAPICluster(capiCluster)
+		defer func() {
+			manager.RemoveSveltosCluster(sc1.Namespace, sc1.Name)
+			manager.RemoveSveltosCluster(sc2.Namespace, sc2.Name)
+			manager.RemoveCAPICluster(capiCluster.Namespace, capiCluster.Name)
+		}()
+
+		counts, err := manager.CountClusters(ctx, true, true, randomString())
+		Expect(err).To(BeNil())
+		Expect(counts.CAPITotal()).To(Equal(initial.CAPITotal() + 1))
+		Expect(counts.SveltosTotal()).To(Equal(initial.SveltosTotal() + 2))
+	})
+
+	It("CountClusters tracks not-ready Sveltos clusters", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		server.InitializeManagerInstance(ctx, nil, c, sc, randomPort(), logger)
+		manager := server.GetManagerInstance()
+
+		initial, err := manager.CountClusters(ctx, true, true, randomString())
+		Expect(err).To(BeNil())
+
+		readyCluster := &libsveltosv1beta1.SveltosCluster{
+			ObjectMeta: metav1.ObjectMeta{Namespace: randomString(), Name: randomString()},
+			Status:     libsveltosv1beta1.SveltosClusterStatus{Ready: true},
+		}
+		notReadyCluster := &libsveltosv1beta1.SveltosCluster{
+			ObjectMeta: metav1.ObjectMeta{Namespace: randomString(), Name: randomString()},
+			Status:     libsveltosv1beta1.SveltosClusterStatus{Ready: false},
+		}
+
+		manager.AddSveltosCluster(readyCluster)
+		manager.AddSveltosCluster(notReadyCluster)
+		defer func() {
+			manager.RemoveSveltosCluster(readyCluster.Namespace, readyCluster.Name)
+			manager.RemoveSveltosCluster(notReadyCluster.Namespace, notReadyCluster.Name)
+		}()
+
+		counts, err := manager.CountClusters(ctx, true, true, randomString())
+		Expect(err).To(BeNil())
+		Expect(counts.SveltosTotal()).To(BeNumerically(">=", 2))
+		Expect(counts.SveltosNotReady()).To(Equal(initial.SveltosNotReady() + 1))
+	})
+
+	It("CountClusters counts pull-mode Sveltos clusters", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		server.InitializeManagerInstance(ctx, nil, c, sc, randomPort(), logger)
+		manager := server.GetManagerInstance()
+
+		initial, err := manager.CountClusters(ctx, true, true, randomString())
+		Expect(err).To(BeNil())
+
+		pullCluster := &libsveltosv1beta1.SveltosCluster{
+			ObjectMeta: metav1.ObjectMeta{Namespace: randomString(), Name: randomString()},
+			Spec:       libsveltosv1beta1.SveltosClusterSpec{PullMode: true},
+		}
+		normalCluster := &libsveltosv1beta1.SveltosCluster{
+			ObjectMeta: metav1.ObjectMeta{Namespace: randomString(), Name: randomString()},
+		}
+
+		manager.AddSveltosCluster(pullCluster)
+		manager.AddSveltosCluster(normalCluster)
+		defer func() {
+			manager.RemoveSveltosCluster(pullCluster.Namespace, pullCluster.Name)
+			manager.RemoveSveltosCluster(normalCluster.Namespace, normalCluster.Name)
+		}()
+
+		counts, err := manager.CountClusters(ctx, true, true, randomString())
+		Expect(err).To(BeNil())
+		Expect(counts.PullMode()).To(Equal(initial.PullMode() + 1))
+	})
+
+	It("CountClusters decreases when a cluster is removed", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		server.InitializeManagerInstance(ctx, nil, c, sc, randomPort(), logger)
+		manager := server.GetManagerInstance()
+
+		sveltosCluster := &libsveltosv1beta1.SveltosCluster{
+			ObjectMeta: metav1.ObjectMeta{Namespace: randomString(), Name: randomString()},
+		}
+		manager.AddSveltosCluster(sveltosCluster)
+		// no defer needed — removal is the point of this test
+
+		before, err := manager.CountClusters(ctx, true, true, randomString())
+		Expect(err).To(BeNil())
+
+		manager.RemoveSveltosCluster(sveltosCluster.Namespace, sveltosCluster.Name)
+
+		after, err := manager.CountClusters(ctx, true, true, randomString())
+		Expect(err).To(BeNil())
+		Expect(after.SveltosTotal()).To(Equal(before.SveltosTotal() - 1))
+	})
+
+	It("CountProfilesByKind correctly separates ClusterProfiles from Profiles", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		server.InitializeManagerInstance(ctx, nil, c, sc, randomPort(), logger)
+		manager := server.GetManagerInstance()
+
+		initialCP, initialP, err := manager.CountProfilesByKind(ctx, true, true, randomString())
+		Expect(err).To(BeNil())
+
+		tier := int32(100)
+
+		cp1 := &corev1.ObjectReference{
+			Name:       randomString(),
+			Kind:       configv1beta1.ClusterProfileKind,
+			APIVersion: configv1beta1.GroupVersion.String(),
+		}
+		cp2 := &corev1.ObjectReference{
+			Name:       randomString(),
+			Kind:       configv1beta1.ClusterProfileKind,
+			APIVersion: configv1beta1.GroupVersion.String(),
+		}
+		p1 := &corev1.ObjectReference{
+			Namespace:  randomString(),
+			Name:       randomString(),
+			Kind:       configv1beta1.ProfileKind,
+			APIVersion: configv1beta1.GroupVersion.String(),
+		}
+
+		manager.AddProfile(cp1, libsveltosv1beta1.Selector{}, tier, configv1beta1.SyncModeContinuous, nil)
+		manager.AddProfile(cp2, libsveltosv1beta1.Selector{}, tier, configv1beta1.SyncModeContinuous, nil)
+		manager.AddProfile(p1, libsveltosv1beta1.Selector{}, tier, configv1beta1.SyncModeContinuous, nil)
+		defer func() {
+			manager.RemoveProfile(cp1)
+			manager.RemoveProfile(cp2)
+			manager.RemoveProfile(p1)
+		}()
+
+		cpCount, pCount, err := manager.CountProfilesByKind(ctx, true, true, randomString())
+		Expect(err).To(BeNil())
+		Expect(cpCount).To(Equal(initialCP + 2))
+		Expect(pCount).To(Equal(initialP + 1))
+	})
+
+	It("CountProfilesByKind decreases when a profile is removed", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		server.InitializeManagerInstance(ctx, nil, c, sc, randomPort(), logger)
+		manager := server.GetManagerInstance()
+
+		cp := &corev1.ObjectReference{
+			Name:       randomString(),
+			Kind:       configv1beta1.ClusterProfileKind,
+			APIVersion: configv1beta1.GroupVersion.String(),
+		}
+		manager.AddProfile(cp, libsveltosv1beta1.Selector{}, 100, configv1beta1.SyncModeContinuous, nil)
+		// no defer needed — removal is the point of this test
+
+		beforeRemove, _, err := manager.CountProfilesByKind(ctx, true, true, randomString())
+		Expect(err).To(BeNil())
+
+		manager.RemoveProfile(cp)
+
+		afterRemove, _, err := manager.CountProfilesByKind(ctx, true, true, randomString())
+		Expect(err).To(BeNil())
+		Expect(afterRemove).To(Equal(beforeRemove - 1))
+	})
+
+	It("CountClusterSummaries returns the number of valid ClusterSummaries in the cache", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		server.InitializeManagerInstance(ctx, nil, c, sc, randomPort(), logger)
+		manager := server.GetManagerInstance()
+
+		initialCount := manager.CountClusterSummaries()
+
+		cluster := createTestCAPICluster(randomString(), randomString())
+		cs1 := createTestClusterSummary("stats-summary1-"+randomString(), cluster.Namespace,
+			cluster.Namespace, cluster.Name, nil)
+		cs2 := createTestClusterSummary("stats-summary2-"+randomString(), cluster.Namespace,
+			cluster.Namespace, cluster.Name, nil)
+
+		manager.AddClusterProfileStatus(cs1)
+		manager.AddClusterProfileStatus(cs2)
+		defer func() {
+			manager.RemoveClusterProfileStatus(cs1.Namespace, cs1.Name)
+			manager.RemoveClusterProfileStatus(cs2.Namespace, cs2.Name)
+		}()
+
+		Expect(manager.CountClusterSummaries()).To(Equal(initialCount + 2))
+	})
+
+	It("CountClusterSummaries decreases when a ClusterSummary is removed", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		server.InitializeManagerInstance(ctx, nil, c, sc, randomPort(), logger)
+		manager := server.GetManagerInstance()
+
+		cluster := createTestCAPICluster(randomString(), randomString())
+		cs := createTestClusterSummary("stats-removal-"+randomString(), cluster.Namespace,
+			cluster.Namespace, cluster.Name, nil)
+
+		manager.AddClusterProfileStatus(cs)
+		// no defer needed — removal is the point of this test
+
+		beforeRemove := manager.CountClusterSummaries()
+
+		manager.RemoveClusterProfileStatus(cs.Namespace, cs.Name)
+		Expect(manager.CountClusterSummaries()).To(Equal(beforeRemove - 1))
+	})
+
+	It("cluster and profile counts are independent of each other", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		server.InitializeManagerInstance(ctx, nil, c, sc, randomPort(), logger)
+		manager := server.GetManagerInstance()
+
+		initialClusters, err := manager.CountClusters(ctx, true, true, randomString())
+		Expect(err).To(BeNil())
+		initialCP, initialP, err := manager.CountProfilesByKind(ctx, true, true, randomString())
+		Expect(err).To(BeNil())
+
+		sveltosCluster := &libsveltosv1beta1.SveltosCluster{
+			ObjectMeta: metav1.ObjectMeta{Namespace: randomString(), Name: randomString()},
+		}
+		cp := &corev1.ObjectReference{
+			Name:       randomString(),
+			Kind:       configv1beta1.ClusterProfileKind,
+			APIVersion: configv1beta1.GroupVersion.String(),
+		}
+
+		manager.AddSveltosCluster(sveltosCluster)
+		manager.AddProfile(cp, libsveltosv1beta1.Selector{}, 100, configv1beta1.SyncModeContinuous, nil)
+		defer func() {
+			manager.RemoveSveltosCluster(sveltosCluster.Namespace, sveltosCluster.Name)
+			manager.RemoveProfile(cp)
+		}()
+
+		afterClusters, err := manager.CountClusters(ctx, true, true, randomString())
+		Expect(err).To(BeNil())
+		cpCount, pCount, err := manager.CountProfilesByKind(ctx, true, true, randomString())
+		Expect(err).To(BeNil())
+
+		Expect(afterClusters.SveltosTotal()).To(Equal(initialClusters.SveltosTotal() + 1))
+		Expect(cpCount).To(Equal(initialCP + 1))
+		Expect(pCount).To(Equal(initialP))
+	})
+})


### PR DESCRIPTION
It returns:

1. number of ClusterAPI Clusters (and not ready ones)
2. number of SveltosClusters (and not ready ones)
3. number of SveltosClusters in pull mode
4. number of ClusterProfiles and Profiles
5. number of ClusterSummaries
6. number of EventTriggers

```
{"capiClusters":1,"notReadyCAPIClusters":0,"sveltosClusters":1,"notReadySveltosClusters":0,"pullModeClusters":0,"clusterProfiles":12,"profiles":0,"clusterSummaries":11,"eventTriggers":1}
```