### PR TITLE
(bug) Cluster with pending updates

### DIFF
--- a/internal/server/manager.go
+++ b/internal/server/manager.go
@@ -466,9 +466,17 @@ func (m *instance) ClusterIsProvisioning(clusterType libsveltosv1beta1.ClusterTy
 
 // clusterSummaryIsProvisioning returns true when the ClusterSummary is actively provisioning
 // without errors. Two conditions qualify:
-//  1. Any feature has Provisioning status with no failure message (clean in-progress deploy).
-//  2. The dependencies field is non-empty (waiting for another ClusterProfile to finish).
+//  1. The dependencies field is non-empty and not all features are Provisioned yet
+//     (waiting for another ClusterProfile to finish).
+//  2. Any feature has Provisioning status with no failure message (clean in-progress deploy).
+//
+// If all features are already Provisioned the ClusterSummary is done regardless of what
+// the dependencies string says — the addon-controller writes informational messages like
+// "All dependencies deployed" even after work is complete.
 func clusterSummaryIsProvisioning(features []ClusterFeatureSummary, dependencies string) bool {
+	if allFeaturesProvisioned(features) {
+		return false
+	}
 	if dependencies != "" {
 		return true
 	}
@@ -481,6 +489,22 @@ func clusterSummaryIsProvisioning(features []ClusterFeatureSummary, dependencies
 		}
 	}
 	return false
+}
+
+// allFeaturesProvisioned returns true when every feature in the ClusterSummary has
+// reached FeatureStatusProvisioned. An empty feature list is not considered fully
+// provisioned — the ClusterSummary may still be waiting on dependencies before
+// deploying begins.
+func allFeaturesProvisioned(features []ClusterFeatureSummary) bool {
+	if len(features) == 0 {
+		return false
+	}
+	for i := range features {
+		if features[i].Status != libsveltosv1beta1.FeatureStatusProvisioned {
+			return false
+		}
+	}
+	return true
 }
 
 // updateClusterProvisioning inserts or erases csRef from the per-cluster provisioning set.

--- a/internal/server/manager_test.go
+++ b/internal/server/manager_test.go
@@ -652,6 +652,27 @@ var _ = Describe("Manager", func() {
 		Expect(manager.ClusterIsProvisioning(libsveltosv1beta1.ClusterTypeCapi, cluster.Namespace, cluster.Name)).To(BeFalse())
 	})
 
+	It("ClusterIsProvisioning returns false when all features are Provisioned even if dependencies string is set", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		server.InitializeManagerInstance(ctx, nil, c, scheme, randomPort(), logger)
+		manager := server.GetManagerInstance()
+
+		// addon-controller sets Status.Dependencies to "All dependencies deployed" even after
+		// the ClusterSummary is fully provisioned; ui-backend must not treat that as provisioning.
+		depMsg := "All dependencies deployed"
+		cs := createTestClusterSummary("cs-provisioned-with-dep-msg", cluster.Namespace, cluster.Namespace, cluster.Name,
+			[]configv1beta1.FeatureSummary{
+				{FeatureID: helmFeatureID, Status: libsveltosv1beta1.FeatureStatusProvisioned},
+			},
+		)
+		cs.Status.Dependencies = &depMsg
+		manager.AddClusterProfileStatus(cs)
+
+		Expect(manager.ClusterIsProvisioning(libsveltosv1beta1.ClusterTypeCapi, cluster.Namespace, cluster.Name)).To(BeFalse())
+	})
+
 	It("ClusterIsProvisioning clears when ClusterSummary is removed", func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()


### PR DESCRIPTION
Before this PR, ui-backedn incorrectly reported a cluster as having pending updates if a profile matched the cluster and had dependencies. This PR fixes that.